### PR TITLE
Sanitize 1Password URIs to avoid silent breakage when special charaсters are used

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,10 @@
+# See https://pre-commit.com for more information
+# See https://pre-commit.com/hooks.html for more hooks
+repos:
+-   repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v6.0.0
+    hooks:
+    -   id: trailing-whitespace
+    -   id: end-of-file-fixer
+    -   id: check-yaml
+    -   id: check-added-large-files

--- a/auth-source-1password.el
+++ b/auth-source-1password.el
@@ -47,23 +47,20 @@ Replace invalid characters with underscore and warn if modified.
 
 Supported characters are listed here
 https://developer.1password.com/docs/cli/secret-reference-syntax/#supported-characters"
-  (let* ((sanitized (replace-regexp-in-string "[^a-zA-Z0-9_.- ]" "_" component))
-         (sanitized (if (string-match "^[0-9]" sanitized)
-                        (concat "_" sanitized)
-                      sanitized)))
-    (unless (string= component sanitized)
-      (warn "auth-source-1password: Sanitized '%s' to '%s' for 1Password compatibility" component sanitized))
-    sanitized))
+  (let* ((sanitized (replace-regexp-in-string "[^-. a-zA-Z0-9]" "_" component)))
+    (if (string-match "^[0-9]" sanitized)
+        (concat "_" sanitized)
+      sanitized)))
 
 (defun auth-source-1password--1password-construct-query-path (_backend _type host user _port)
   "Construct the full entry-path for the 1password entry for HOST and USER.
 Usually starting with the `auth-source-1password-vault', followed
 by host and user."
-  (mapconcat #'identity
-             (list (auth-source-1password--sanitize-component auth-source-1password-vault)
-                   (auth-source-1password--sanitize-component host)
-                   (auth-source-1password--sanitize-component user))
-             "/"))
+  (string-join
+   (list (auth-source-1password--sanitize-component auth-source-1password-vault)
+         (auth-source-1password--sanitize-component host)
+         (auth-source-1password--sanitize-component user))
+   "/"))
 
 (cl-defun auth-source-1password-search (&rest spec
                                               &key backend type host user port
@@ -71,12 +68,14 @@ by host and user."
   "Search 1password for the specified user and host.
 SPEC, BACKEND, TYPE, HOST, USER and PORT are required by auth-source."
   (if (executable-find auth-source-1password-executable)
-      (let ((got-secret
-             (string-trim
-              (shell-command-to-string
-               (format "%s read op://%s"
-                       auth-source-1password-executable
-                       (shell-quote-argument (funcall auth-source-1password-construct-secret-reference backend type host user port)))))))
+      (let* ((reference (funcall auth-source-1password-construct-secret-reference backend type host user port))
+             (got-secret
+              (string-trim
+               (shell-command-to-string
+                (format "%s read op://%s"
+                        auth-source-1password-executable
+                        (shell-quote-argument reference))))))
+        (warn "Reference used '%s'" reference)
         (list (list :user user
                     :secret got-secret)))
     (warn "`auth-source-1password': Could not find executable '%s' to query 1password" auth-source-1password-executable)))
@@ -110,13 +109,14 @@ SPEC, BACKEND, TYPE, HOST, USER and PORT are required by auth-source."
 
 (ert-deftest auth-source-1password--sanitize-component-valid ()
   "Test sanitization with valid characters."
-  (should (string= "valid_host.com" (auth-source-1password--sanitize-component "valid_host.com")))
+  (should (string= "example.com" (auth-source-1password--sanitize-component "example.com")))
   (should (string= "user-name" (auth-source-1password--sanitize-component "user-name")))
+  (should (string= "host with spaces" (auth-source-1password--sanitize-component "host with spaces")))
   (should (string= "vault123" (auth-source-1password--sanitize-component "vault123"))))
 
 (ert-deftest auth-source-1password--sanitize-component-invalid ()
   "Test sanitization with invalid characters."
-  (should (string= "host_with_spaces" (auth-source-1password--sanitize-component "host with spaces")))
+
   (should (string= "user_name" (auth-source-1password--sanitize-component "user@name")))
   (should (string= "special___chars" (auth-source-1password--sanitize-component "special!@#chars"))))
 
@@ -132,13 +132,13 @@ SPEC, BACKEND, TYPE, HOST, USER and PORT are required by auth-source."
 (ert-deftest auth-source-1password--construct-query-path-valid ()
   "Test path construction with valid components."
   (let ((auth-source-1password-vault "Personal"))
-    (should (string= "Personal/example.com/user"
-                     (auth-source-1password--1password-construct-query-path nil nil "example.com" "user" nil)))))
+    (should (string= "Personal/example.com/user name"
+                     (auth-source-1password--1password-construct-query-path nil nil "example.com" "user name" nil)))))
 
 (ert-deftest auth-source-1password--construct-query-path-sanitized ()
   "Test path construction with components needing sanitization."
-  (let ((auth-source-1password-vault "Personal Vault"))
-    (should (string= "Personal_Vault/host_with_spaces/user_name"
-                     (auth-source-1password--1password-construct-query-path nil nil "host with spaces" "user@name" nil)))))
+  (let ((auth-source-1password-vault "Personal%Vault"))
+    (should (string= "Personal_Vault/host_with_symbols/user_name"
+                     (auth-source-1password--1password-construct-query-path nil nil "host&with#symbols" "user@name" nil)))))
 
 ;;; auth-source-1password.el ends here

--- a/auth-source-1password.el
+++ b/auth-source-1password.el
@@ -40,16 +40,35 @@
   :type 'function
   :group 'auth-source-1password)
 
+(defun auth-source-1password--sanitize-component (component)
+  "Sanitize COMPONENT for 1Password CLI secret reference.
+
+Replace invalid characters with underscore and warn if modified.
+
+Supported characters are listed here
+https://developer.1password.com/docs/cli/secret-reference-syntax/#supported-characters"
+  (let* ((sanitized (replace-regexp-in-string "[^a-zA-Z0-9_.- ]" "_" component))
+         (sanitized (if (string-match "^[0-9]" sanitized)
+                        (concat "_" sanitized)
+                      sanitized)))
+    (unless (string= component sanitized)
+      (warn "auth-source-1password: Sanitized '%s' to '%s' for 1Password compatibility" component sanitized))
+    sanitized))
+
 (defun auth-source-1password--1password-construct-query-path (_backend _type host user _port)
   "Construct the full entry-path for the 1password entry for HOST and USER.
 Usually starting with the `auth-source-1password-vault', followed
 by host and user."
-  (mapconcat #'identity (list auth-source-1password-vault host user) "/"))
+  (mapconcat #'identity
+             (list (auth-source-1password--sanitize-component auth-source-1password-vault)
+                   (auth-source-1password--sanitize-component host)
+                   (auth-source-1password--sanitize-component user))
+             "/"))
 
 (cl-defun auth-source-1password-search (&rest spec
-                                           &key backend type host user port
-                                           &allow-other-keys)
-  "Searche 1password for the specified user and host.
+                                              &key backend type host user port
+                                              &allow-other-keys)
+  "Search 1password for the specified user and host.
 SPEC, BACKEND, TYPE, HOST, USER and PORT are required by auth-source."
   (if (executable-find auth-source-1password-executable)
       (let ((got-secret
@@ -60,7 +79,6 @@ SPEC, BACKEND, TYPE, HOST, USER and PORT are required by auth-source."
                        (shell-quote-argument (funcall auth-source-1password-construct-secret-reference backend type host user port)))))))
         (list (list :user user
                     :secret got-secret)))
-    ;; If not executable was found, return nil and show a warning
     (warn "`auth-source-1password': Could not find executable '%s' to query 1password" auth-source-1password-executable)))
 
 ;;;###autoload
@@ -85,4 +103,42 @@ SPEC, BACKEND, TYPE, HOST, USER and PORT are required by auth-source."
   (advice-add 'auth-source-backend-parse :before-until #'auth-source-1password-backend-parse))
 
 (provide 'auth-source-1password)
+
+;;; Tests
+(eval-when-compile
+  (require 'ert))
+
+(ert-deftest auth-source-1password--sanitize-component-valid ()
+  "Test sanitization with valid characters."
+  (should (string= "valid_host.com" (auth-source-1password--sanitize-component "valid_host.com")))
+  (should (string= "user-name" (auth-source-1password--sanitize-component "user-name")))
+  (should (string= "vault123" (auth-source-1password--sanitize-component "vault123"))))
+
+(ert-deftest auth-source-1password--sanitize-component-invalid ()
+  "Test sanitization with invalid characters."
+  (should (string= "host_with_spaces" (auth-source-1password--sanitize-component "host with spaces")))
+  (should (string= "user_name" (auth-source-1password--sanitize-component "user@name")))
+  (should (string= "special___chars" (auth-source-1password--sanitize-component "special!@#chars"))))
+
+(ert-deftest auth-source-1password--sanitize-component-leading-number ()
+  "Test sanitization with leading numbers."
+  (should (string= "_123host" (auth-source-1password--sanitize-component "123host")))
+  (should (string= "_456user" (auth-source-1password--sanitize-component "456user"))))
+
+(ert-deftest auth-source-1password--sanitize-component-empty ()
+  "Test sanitization with empty string."
+  (should (string= "" (auth-source-1password--sanitize-component ""))))
+
+(ert-deftest auth-source-1password--construct-query-path-valid ()
+  "Test path construction with valid components."
+  (let ((auth-source-1password-vault "Personal"))
+    (should (string= "Personal/example.com/user"
+                     (auth-source-1password--1password-construct-query-path nil nil "example.com" "user" nil)))))
+
+(ert-deftest auth-source-1password--construct-query-path-sanitized ()
+  "Test path construction with components needing sanitization."
+  (let ((auth-source-1password-vault "Personal Vault"))
+    (should (string= "Personal_Vault/host_with_spaces/user_name"
+                     (auth-source-1password--1password-construct-query-path nil nil "host with spaces" "user@name" nil)))))
+
 ;;; auth-source-1password.el ends here


### PR DESCRIPTION
As the title suggests, in case the host/username contains anything but [the allowed characters](https://developer.1password.com/docs/cli/secrets-template-syntax/#unenclosed-secret-references) the current implementation would silently fail. To address this convert all unsupported characters to underscore.

This was prompted by attempting to use this library with magit's forge which does not (to the best of my knowledge) allow setting specific user field and uses `username^forge` format to query secrets. 